### PR TITLE
Refresh resolvers using an Executor with Daemon threads, allow graceful automatic app terminations

### DIFF
--- a/java-props-benchmark/src/main/java/benchmark/GenericBenchmarks.java
+++ b/java-props-benchmark/src/main/java/benchmark/GenericBenchmarks.java
@@ -154,7 +154,6 @@ public class GenericBenchmarks {
     @TearDown
     public void teardown() {
       executor.shutdownNow();
-      props.close();
     }
   }
 }

--- a/java-props-benchmark/src/main/java/benchmark/PubSubMain.java
+++ b/java-props-benchmark/src/main/java/benchmark/PubSubMain.java
@@ -57,7 +57,7 @@ public class PubSubMain {
     log(
         "Waiting for the JVM to finish loading classes and allowing the user to attach"
             + " profilers...");
-    sleep(2 * SLEEP_MILLIS);
+    sleep(SLEEP_MILLIS);
 
     log("Initializing the environment...");
 
@@ -138,7 +138,6 @@ public class PubSubMain {
       sleep(3 * SLEEP_MILLIS);
     }
 
-    props.close();
     scheduler.shutdownNow();
     log("Done.");
     sleep(SLEEP_MILLIS);

--- a/java-props-core/src/test/java/com/mihaibojin/props/core/PropsTest.java
+++ b/java-props-core/src/test/java/com/mihaibojin/props/core/PropsTest.java
@@ -19,11 +19,7 @@ package com.mihaibojin.props.core;
 import static com.mihaibojin.props.core.resolvers.ResolverUtils.readResolverConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
-import com.mihaibojin.props.core.Props.Factory;
 import com.mihaibojin.props.core.converters.Cast;
 import com.mihaibojin.props.core.converters.Converter;
 import com.mihaibojin.props.core.converters.DurationConverter;
@@ -88,30 +84,6 @@ public class PropsTest {
 
     // ASSERT
     assertThat(aValue, equalTo(1));
-  }
-
-  @Test
-  void shutdownHookIsRegistered() {
-    // ARRANGE
-    Factory factory = spy(Props.factory());
-
-    // ACT
-    Props props = factory.withResolver(new EnvResolver()).registerShutdownHook(true).build();
-
-    // ASSERT
-    verify(factory).registerShutdownHook(props);
-  }
-
-  @Test
-  void shutdownHookIsNotRegistered() {
-    // ARRANGE
-    Factory factory = spy(Props.factory());
-
-    // ACT
-    Props props = factory.withResolver(new EnvResolver()).registerShutdownHook(false).build();
-
-    // ASSERT
-    verify(factory, never()).registerShutdownHook(props);
   }
 
   @Test

--- a/java-props-core/src/test/java/examples/UpdatesSubscriberExamplesTest.java
+++ b/java-props-core/src/test/java/examples/UpdatesSubscriberExamplesTest.java
@@ -30,7 +30,6 @@ import com.mihaibojin.props.core.types.AbstractStringProp;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,11 +71,6 @@ public class UpdatesSubscriberExamplesTest {
         "The last update matches the expected value",
         data.getLast(),
         equalTo("value" + (elements - 1)));
-  }
-
-  @AfterEach
-  void tearDown() {
-    props.close();
   }
 
   private class StringProp extends AbstractStringProp {


### PR DESCRIPTION
<!--
Thank you for contributing to `props`!

Before you submit your pull request, please review the project's 
[contribution guidelines](../CONTRIBUTING.md).

Please ensure all the requirements below are met and then tag the PR with the `in-review` label.
-->

# What does this Pull Request do?

Switched to using a ScheduledExecutor with Daemon threads, and simplified Props's API but avoiding the user to have to call `Props.close()` before app shutdowns.

<!-- and link any issues, e.g.: -->
closes #63


# Details

<!-- 
Add in-depth details, if necessary, especially if you think it will aid in the review process.
-->


## Checklist

Please ensure the following conditions are met:

- [x] I have signed the [CLA](../CLA.md) (additional [details here](/contributors/README.md))
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)

If you're unsure about any of the above, please get in touch!
